### PR TITLE
Updated StateChange fields and stateChange for transitions to same state.

### DIFF
--- a/chan_handler.go
+++ b/chan_handler.go
@@ -13,7 +13,11 @@ type ChanHandler struct {
 
 // StateChange captures "from" and "to" States for the ChanHandler.
 type StateChange struct {
-	from, to State
+	// From is the previous state.
+	From State
+
+	// To is the new state.
+	To State
 }
 
 func NewChanHandler(scCh chan<- StateChange, errCh chan<- error) *ChanHandler {
@@ -25,7 +29,7 @@ func NewChanHandler(scCh chan<- StateChange, errCh chan<- error) *ChanHandler {
 
 // Queue the state change onto the channel
 func (chand *ChanHandler) StateChange(from, to State) {
-	chand.stateChangeChan <- StateChange{from, to}
+	chand.stateChangeChan <- StateChange{From: from, To: to}
 }
 
 // Queue the error onto the channel

--- a/handler_test.go
+++ b/handler_test.go
@@ -45,11 +45,11 @@ func TestStateChangeHandler(t *testing.T) {
 	defer node.Close()
 
 	sc := wait(t, scCh)
-	if sc.from != FOLLOWER && sc.to != CANDIDATE {
+	if sc.From != FOLLOWER && sc.To != CANDIDATE {
 		t.Fatalf("Did not receive correct states for state change: %+v\n", sc)
 	}
 	sc = wait(t, scCh)
-	if sc.from != CANDIDATE && sc.to != LEADER {
+	if sc.From != CANDIDATE && sc.To != LEADER {
 		t.Fatalf("Did not receive correct states for state change: %+v\n", sc)
 	}
 
@@ -58,7 +58,7 @@ func TestStateChangeHandler(t *testing.T) {
 	node.HeartBeats <- &Heartbeat{Term: newTerm, Leader: "new"}
 
 	sc = wait(t, scCh)
-	if sc.from != LEADER && sc.to != FOLLOWER {
+	if sc.From != LEADER && sc.To != FOLLOWER {
 		t.Fatalf("Did not receive correct states for state change: %+v\n", sc)
 	}
 }

--- a/node.go
+++ b/node.go
@@ -517,6 +517,9 @@ func (n *Node) switchToCandidate() {
 // Process a state transistion. Assume lock is held on entrance.
 // Call the async handler in a separate Go routine.
 func (n *Node) switchState(state State) {
+	if state == n.state {
+		return
+	}
 	old := n.state
 	n.state = state
 	go n.handler.StateChange(old, state)


### PR DESCRIPTION
Changed StateChange from/to fields to be exported. The StateChange struct is
public, but its fields weren't, meaning ChanHandler was useless to know what
the transition was for.

Also changed node.stateChange to not trigger a state change notification if
the new state is the same as the current state. It was noticed that if a
client is in the candidate state, then it would send the notification each
time the voting timeout expired even though it wasn't actually in a different
state.

@derekcollison 
