### PR TITLE
Update Travis + Fixed flapping tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: go
 sudo: false
 go:
-- 1.5
+- 1.6.3
 
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd
-- go get golang.org/x/tools/cmd/vet
-- go get golang.org/x/tools/cmd/cover
 - go get github.com/mattn/goveralls
+- go get github.com/wadey/gocovmerge
 
 script:
   - go fmt ./...
   - go vet ./...
   - go test -i -race ./...
   - go test -v -race ./...
-  - go test -v -covermode=count -coverprofile=coverage.out
-  - $HOME/gopath/bin/goveralls -coverprofile coverage.out -service travis-ci
+  - ./scripts/cov.sh TRAVIS

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -47,10 +47,10 @@ func TestHeartBeatAsFollower(t *testing.T) {
 	// Any HeartBeat will set the Leader if none given.
 	sendAndWait(node, &Heartbeat{Term: term, Leader: leader})
 
-	if state := node.State(); state != FOLLOWER {
+	if state := waitForState(node, FOLLOWER); state != FOLLOWER {
 		t.Fatalf("Expected Node to be in Follower state, got: %s", state)
 	}
-	if curLeader := node.Leader(); curLeader != leader {
+	if curLeader := waitForLeader(node, leader); curLeader != leader {
 		t.Fatalf("Expected leader to be %s, got: %s\n", leader, curLeader)
 	}
 
@@ -62,10 +62,10 @@ func TestHeartBeatAsFollower(t *testing.T) {
 	oldLeader := "oldleader"
 	sendAndWait(node, &Heartbeat{Term: 1, Leader: oldLeader})
 
-	if state := node.State(); state != FOLLOWER {
+	if state := waitForState(node, FOLLOWER); state != FOLLOWER {
 		t.Fatalf("Expected Node to be in Follower state, got: %s", state)
 	}
-	if curLeader := node.Leader(); curLeader != leader {
+	if curLeader := waitForLeader(node, leader); curLeader != leader {
 		t.Fatalf("Expected leader to be %s, got: %s\n", leader, curLeader)
 	}
 
@@ -77,10 +77,10 @@ func TestHeartBeatAsFollower(t *testing.T) {
 	newTerm := uint64(10)
 	sendAndWait(node, &Heartbeat{Term: newTerm, Leader: newLeader})
 
-	if state := node.State(); state != FOLLOWER {
+	if state := waitForState(node, FOLLOWER); state != FOLLOWER {
 		t.Fatalf("Expected Node to be in Follower state, got: %s", state)
 	}
-	if curLeader := node.Leader(); curLeader != newLeader {
+	if curLeader := waitForLeader(node, newLeader); curLeader != newLeader {
 		t.Fatalf("Expected leader to be %s, got: %s\n", newLeader, curLeader)
 	}
 	if node.CurrentTerm() != newTerm {
@@ -122,10 +122,10 @@ func TestHeartBeatAsCandidate(t *testing.T) {
 	// Any HeartBeat will set the Leader if none given.
 	sendAndWait(node, &Heartbeat{Term: term, Leader: leader})
 
-	if state := node.State(); state != CANDIDATE {
+	if state := waitForState(node, CANDIDATE); state != CANDIDATE {
 		t.Fatalf("Expected Node to be in Candidate state, got: %s", state)
 	}
-	if curLeader := node.Leader(); curLeader != NO_LEADER {
+	if curLeader := waitForLeader(node, NO_LEADER); curLeader != NO_LEADER {
 		t.Fatalf("Expected no leader, got: %s\n", curLeader)
 	}
 
@@ -135,10 +135,10 @@ func TestHeartBeatAsCandidate(t *testing.T) {
 
 	sendAndWait(node, &Heartbeat{Term: newTerm, Leader: newLeader})
 
-	if state := node.State(); state != FOLLOWER {
+	if state := waitForState(node, FOLLOWER); state != FOLLOWER {
 		t.Fatalf("Expected Node to be in Follower state, got: %s", state)
 	}
-	if curLeader := node.Leader(); curLeader != newLeader {
+	if curLeader := waitForLeader(node, newLeader); curLeader != newLeader {
 		t.Fatalf("Expected leader to be %s, got: %s\n", newLeader, curLeader)
 	}
 	if node.CurrentTerm() != newTerm {
@@ -172,10 +172,10 @@ func TestHeartBeatAsLeader(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Verify new state
-	if state := node.State(); state != CANDIDATE {
+	if state := waitForState(node, CANDIDATE); state != CANDIDATE {
 		t.Fatalf("Expected Node to be in Candidate state, got: %s", state)
 	}
-	if curLeader := node.Leader(); curLeader != NO_LEADER {
+	if curLeader := waitForLeader(node, NO_LEADER); curLeader != NO_LEADER {
 		t.Fatalf("Expected no leader, got: %s\n", curLeader)
 	}
 
@@ -186,10 +186,10 @@ func TestHeartBeatAsLeader(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	if state := node.State(); state != LEADER {
+	if state := waitForState(node, LEADER); state != LEADER {
 		t.Fatalf("Expected Node to be in Leader state, got: %s", state)
 	}
-	if curLeader := node.Leader(); curLeader != node.Id() {
+	if curLeader := waitForLeader(node, node.Id()); curLeader != node.Id() {
 		t.Fatalf("Expected us to be leader, got: %s\n", curLeader)
 	}
 	if node.CurrentTerm() != vreq.Term {
@@ -207,10 +207,10 @@ func TestHeartBeatAsLeader(t *testing.T) {
 	// Any HeartBeat will set the Leader if none given.
 	sendAndWait(node, &Heartbeat{Term: term, Leader: leader})
 
-	if state := node.State(); state != LEADER {
+	if state := waitForState(node, LEADER); state != LEADER {
 		t.Fatalf("Expected Node to be in Leader state, got: %s", state)
 	}
-	if curLeader := node.Leader(); curLeader != node.Id() {
+	if curLeader := waitForLeader(node, node.Id()); curLeader != node.Id() {
 		t.Fatalf("Expected us to be leader, got: %s\n", curLeader)
 	}
 
@@ -223,10 +223,10 @@ func TestHeartBeatAsLeader(t *testing.T) {
 
 	sendAndWait(node, &Heartbeat{Term: newTerm, Leader: newLeader})
 
-	if state := node.State(); state != FOLLOWER {
+	if state := waitForState(node, FOLLOWER); state != FOLLOWER {
 		t.Fatalf("Expected Node to be in Follower state, got: %s", state)
 	}
-	if curLeader := node.Leader(); curLeader != newLeader {
+	if curLeader := waitForLeader(node, newLeader); curLeader != newLeader {
 		t.Fatalf("Expected leader to be %s, got: %s\n", newLeader, curLeader)
 	}
 	if node.CurrentTerm() != newTerm {

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+# Run from directory above via ./scripts/cov.sh
+
+rm -rf ./cov
+mkdir cov
+go test -v -covermode=count -coverprofile=./cov/graft.out
+gocovmerge ./cov/*.out > acc.out
+rm -rf ./cov
+
+# If we have an arg, assume travis run and push to coveralls. Otherwise launch browser results
+if [[ -n $1 ]]; then
+    $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci
+    rm -rf ./acc.out
+else
+    go tool cover -html=acc.out
+fi

--- a/test_helper.go
+++ b/test_helper.go
@@ -5,6 +5,7 @@ package graft
 import (
 	"io/ioutil"
 	"testing"
+	"time"
 )
 
 type dummyHandler struct {
@@ -77,4 +78,30 @@ func expectedClusterState(t *testing.T, nodes []*Node, leaders, followers, candi
 		t.Fatalf("Cluster doesn't match expect state: expected %d leaders, %d followers, %d candidates, actual %d Leaders, %d followers, %d candidates\n",
 			leaders, followers, candidates, currentLeaders, currentFollowers, currentCandidates)
 	}
+}
+
+func waitForLeader(node *Node, expectedLeader string) string {
+	curLeader := ""
+	timeout := time.Now().Add(5 * time.Second)
+	for time.Now().Before(timeout) {
+		curLeader = node.Leader()
+		if curLeader == expectedLeader {
+			return expectedLeader
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return curLeader
+}
+
+func waitForState(node *Node, expectedState State) State {
+	curState := FOLLOWER
+	timeout := time.Now().Add(5 * time.Second)
+	for time.Now().Before(timeout) {
+		curState = node.State()
+		if curState == expectedState {
+			return expectedState
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return curState
 }


### PR DESCRIPTION
Was getting failures with `-race` for heartbeat tests.
The util function sendAndWait() just ensures that the heartbeat
has been dequeued. Change in state and/or leader is not guaranteed
at this point. Added waitForLeader and waitForState to wait for
a certain amount of time for the expected leader/state. Used these
in various places, may need to use it in some other places if we
get other tests failures.