### PR TITLE
[FIXED] Ensure state changes are posted in order they occur

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -15,7 +15,10 @@ func wait(t *testing.T, ch chan StateChange) *StateChange {
 	select {
 	case sc := <-ch:
 		return &sc
-	case <-time.After(MAX_ELECTION_TIMEOUT):
+	// It could be that the random election time is the max. Inc
+	// that case, the node will still need a bit more time to
+	// transition.
+	case <-time.After(MAX_ELECTION_TIMEOUT + 50*time.Millisecond):
 		t.Fatal("Timeout waiting on state change")
 	}
 	return nil


### PR DESCRIPTION
Both state changes and errors were posted through the use of a go
routine. This did not guarantee that the changes would arrive in
the state change handler in the same order they were produced.

Resolves #11