### PR TITLE
[UPDATED] Dependencies and all travis warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: go
 sudo: false
 go:
+- 1.21.x
 - 1.20.x
-- 1.19.x
 go_import_path: github.com/nats-io/graft
 
 install:
 - go get -t ./...
-- if [[ "$TRAVIS_GO_VERSION" =~ 1.20 ]]; then
+- if [[ "$TRAVIS_GO_VERSION" =~ 1.21 ]]; then
     go install github.com/mattn/goveralls@latest;
     go install github.com/wadey/gocovmerge@latest;
     go install honnef.co/go/tools/cmd/staticcheck@latest;
@@ -17,12 +17,12 @@ install:
 before_script:
 - $(exit $(go fmt ./... | wc -l))
 - go vet ./...
-- if [[ "$TRAVIS_GO_VERSION" =~ 1.20 ]]; then
+- if [[ "$TRAVIS_GO_VERSION" =~ 1.21 ]]; then
     find . -type f -name "*.go" | xargs misspell -error -locale US;
     staticcheck ./...;
   fi
 
 script:
-  - if [[ "$TRAVIS_GO_VERSION" =~ 1.20 ]]; then ./scripts/cov.sh TRAVIS; else go test -race -v -p=1 ./... --failfast -vet=off; fi
+  - if [[ "$TRAVIS_GO_VERSION" =~ 1.21 ]]; then ./scripts/cov.sh TRAVIS; else go test -race -v -p=1 ./... --failfast -vet=off; fi
 after_success:
-  - if [[ "$TRAVIS_GO_VERSION" =~ 1.20 ]]; then $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci; fi
+  - if [[ "$TRAVIS_GO_VERSION" =~ 1.21 ]]; then $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci; fi

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A RAFT Election implementation in Go. More information on RAFT can be found in t
 ) and this [video](http://www.youtube.com/watch?v=YbZ3zDzDnrw&list=WL20FE97C942825E1E).
 
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Build Status](https://travis-ci.com/nats-io/graft.svg?branch=main)](http://travis-ci.com/nats-io/graft)
+[![Build Status](https://travis-ci.com/nats-io/graft.svg?branch=main)](https://app.travis-ci.com/github/nats-io/graft)
 [![Coverage Status](https://coveralls.io/repos/github/nats-io/graft/badge.svg)](https://coveralls.io/github/nats-io/graft)
 
 Overview

--- a/log.go
+++ b/log.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2020 The NATS Authors
+// Copyright 2013-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 )
 
@@ -82,11 +81,11 @@ func (n *Node) writeState() error {
 		return err
 	}
 
-	return ioutil.WriteFile(logPath, toWrite, 0660)
+	return os.WriteFile(logPath, toWrite, 0660)
 }
 
 func (n *Node) readState(path string) (*persistentState, error) {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/log_test.go
+++ b/log_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2020 The NATS Authors
+// Copyright 2013-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package graft
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -26,11 +25,8 @@ func TestLogPermissions(t *testing.T) {
 	hand, rpc, log := genNodeArgs(t)
 	// remove it
 	os.Remove(log)
-	tmpDir, err := ioutil.TempDir("", "_grafty")
-	if err != nil {
-		t.Fatal("Could not create tmp dir")
-	}
-	file, _ := ioutil.TempFile(tmpDir, "_log")
+	tmpDir := t.TempDir()
+	file, _ := os.CreateTemp(tmpDir, "_log")
 	os.Chmod(tmpDir, 0400)
 
 	defer file.Close()
@@ -147,7 +143,7 @@ func TestCorruption(t *testing.T) {
 	testStateOfNode(t, node)
 
 	// Now introduce some corruption
-	buf, err := ioutil.ReadFile(node.logPath)
+	buf, err := os.ReadFile(node.logPath)
 	if err != nil {
 		t.Fatalf("Could not read logfile: %v", err)
 	}
@@ -158,10 +154,10 @@ func TestCorruption(t *testing.T) {
 	env.Data = []byte("ZZZZ")
 	toWrite, err := json.Marshal(env)
 	if err != nil {
-		t.Fatalf("Error Marshalling envelope: %v", err)
+		t.Fatalf("Error Marshaling envelope: %v", err)
 	}
 
-	if err := ioutil.WriteFile(node.logPath, toWrite, 0660); err != nil {
+	if err := os.WriteFile(node.logPath, toWrite, 0660); err != nil {
 		t.Fatalf("Error writing envelope: %v", err)
 	}
 

--- a/node.go
+++ b/node.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2020 The NATS Authors
+// Copyright 2013-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -600,7 +600,7 @@ func (n *Node) postStateChange(sc *StateChange) {
 	}()
 }
 
-// Process a state transistion. Assume lock is held on entrance.
+// Process a state transition. Assume lock is held on entrance.
 // Call the async handler in a separate Go routine.
 func (n *Node) switchState(state State) {
 	if state == n.state {

--- a/test_helper.go
+++ b/test_helper.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2018 The NATS Authors
+// Copyright 2013-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,7 @@ package graft
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -54,7 +54,7 @@ func stackFatalf(t *testing.T, f string, args ...interface{}) {
 func genNodeArgs(t *testing.T) (Handler, RPCDriver, string) {
 	hand := &dummyHandler{}
 	rpc := NewMockRpc()
-	log, err := ioutil.TempFile("", "_grafty_log")
+	log, err := os.CreateTemp(t.TempDir(), "_grafty_log")
 	if err != nil {
 		t.Fatal("Could not create the log file")
 	}


### PR DESCRIPTION
Also upgraded go version on travis to 1.20 and 1.21. 

 Signed-off-by: Derek Collison <derek@nats.io>